### PR TITLE
Add k8s deployment details

### DIFF
--- a/vector-test/README.md
+++ b/vector-test/README.md
@@ -1,0 +1,77 @@
+# Vector Centralized Deployment
+
+This repository provides an example of deploying [Vector](https://vector.dev/) in a centralized topology using Ansible and Docker.
+
+Vector will run in a container and accept logs and metrics from multiple sources:
+
+- **Datadog agents** via `vector` and `statsd` sources.
+- **Splunk** forwarders via `syslog` or `http`.
+- **OpenTelemetry (OTEL)** collectors via the `otlp` source.
+- **Filebeat** via `syslog`.
+
+Logs and metrics can be processed with VRL transforms and shipped to sinks such as Datadog, Elasticsearch, and Splunk. The example configuration shows a simple `remap` transform that adds tags, followed by a `filter` that keeps only error-level events and a `sample` transform that forwards a percentage of messages.
+
+Placeholders are used for tokens and endpoint URLs. Update them for your environment before deployment.
+
+## Directory Structure
+
+```
+vector-test/
+  ansible/
+    deploy.yml            # Playbook to deploy Vector
+    inventory             # Inventory file with hosts
+    roles/
+      vector/
+        tasks/main.yml    # Tasks to run Vector container
+        templates/
+          vector.yaml.j2  # Vector configuration template
+```
+
+## Quick Start
+
+1. Edit `ansible/inventory` and add the hosts where Vector should run.
+2. Edit `ansible/roles/vector/templates/vector.yaml.j2` to customize sources, transforms, and sinks.
+3. Run the playbook:
+
+```bash
+ansible-playbook -i ansible/inventory ansible/deploy.yml
+```
+
+Docker must be installed on the target host(s). The playbook will copy the Vector configuration and run the container.
+
+
+## Kubernetes Deployment with Datadog Agents
+
+This example assumes the Datadog Agent is already deployed as a Helm chart in multiple Kubernetes clusters. To forward container logs to the centralized Vector instance you can override the following values in the chart:
+
+```yaml
+# values.yaml snippet
+ datadog:
+   logs:
+     enabled: true
+     containerCollectAll: true
+   env:
+     - name: DD_LOGS_CONFIG_DD_URL
+       value: "http://VECTOR_VIP:9001"
+     - name: DD_LOGS_CONFIG_LOGS_DD_URL
+       value: "http://VECTOR_VIP:9001"
+```
+
+Replace `VECTOR_VIP` with the address of the load balancer in front of the Vector deployment. Metrics do not need a custom endpoint and will continue to flow directly to Datadog using the standard site settings.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Kubernetes Clusters"
+        A[Datadog Agent Daemonset] -- logs --> LB[Vector Load Balancer]
+        A -. metrics .-> DD[Datadog Metrics Intake]
+    end
+    LB --> V[Vector Instances]
+    V --> OP[Observability Pipelines VIP]
+    OP --> D[Datadog]
+    V --> ES[Elasticsearch]
+    V --> SP[Splunk]
+```
+
+Logs are forwarded from the Datadog Agents through the Vector VIP. Vector processes the events with VRL and then ships them to your Observability Pipelines endpoint before ultimately sending them to Datadog, as well as to any additional sinks such as Elasticsearch or Splunk.

--- a/vector-test/ansible/deploy.yml
+++ b/vector-test/ansible/deploy.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  become: yes
+  vars:
+    vector_config_path: /etc/vector/vector.yaml
+    vector_version: "0.34.1"  # adjust as needed
+  roles:
+    - vector

--- a/vector-test/ansible/inventory
+++ b/vector-test/ansible/inventory
@@ -1,0 +1,2 @@
+[vector_servers]
+vector-host ansible_host=PLACEHOLDER_IP

--- a/vector-test/ansible/roles/vector/tasks/main.yml
+++ b/vector-test/ansible/roles/vector/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Ensure Vector config directory exists
+  file:
+    path: "/etc/vector"
+    state: directory
+    mode: '0755'
+
+- name: Deploy vector configuration
+  template:
+    src: vector.yaml.j2
+    dest: "{{ vector_config_path }}"
+    mode: '0644'
+
+- name: Run Vector container
+  community.docker.docker_container:
+    name: vector
+    image: "timberio/vector:{{ vector_version }}-alpine"
+    state: started
+    restart_policy: unless-stopped
+    volumes:
+      - "{{ vector_config_path }}:/etc/vector/vector.yaml:ro"
+    ports:
+      - "4317:4317"    # OTEL
+      - "10514:10514"  # Filebeat/Splunk syslog
+      - "9001:9001"    # Datadog logs
+      - "8125:8125/udp" # StatsD metrics
+    env:
+      DD_API_KEY: "{{ lookup('env','DD_API_KEY') | default('DD_API_KEY_PLACEHOLDER') }}"
+      SPLUNK_TOKEN: "{{ lookup('env','SPLUNK_TOKEN') | default('SPLUNK_TOKEN_PLACEHOLDER') }}"

--- a/vector-test/ansible/roles/vector/templates/vector.yaml.j2
+++ b/vector-test/ansible/roles/vector/templates/vector.yaml.j2
@@ -1,0 +1,68 @@
+# Vector configuration - centralized aggregator
+# Update endpoints and tokens as needed
+
+data_dir: /var/lib/vector
+
+sources:
+  otel:
+    type: otlp
+    address: 0.0.0.0:4317
+
+  filebeat_logs:
+    type: syslog
+    address: 0.0.0.0:10514
+
+  datadog_logs:
+    type: vector
+    address: 0.0.0.0:9001
+
+  datadog_metrics:
+    type: statsd
+    address: 0.0.0.0:8125
+
+  splunk_forwarder:
+    type: syslog
+    address: 0.0.0.0:1514
+
+transforms:
+  add_tags:
+    type: remap
+    inputs:
+      - otel
+      - filebeat_logs
+      - datadog_logs
+      - datadog_metrics
+      - splunk_forwarder
+    source: |
+      .tags.service = get(.service) ?? "unknown"
+
+  filter_errors:
+    type: filter
+    inputs: [add_tags]
+    condition: '.log_level == "error"'
+
+  sample_logs:
+    type: sample
+    inputs: [filter_errors]
+    rate: 0.1
+
+sinks:
+  to_datadog:
+    type: datadog_logs
+    inputs: [sample_logs]
+    default_api_key: "${DD_API_KEY}"
+    endpoint: "https://http-intake.logs.datadoghq.com/v1/input"
+
+  to_elasticsearch:
+    type: elasticsearch
+    inputs: [sample_logs]
+    endpoints: ["https://elasticsearch.example.com"]
+    index: "vector-%Y-%m-%d"
+
+  to_splunk:
+    type: splunk_hec
+    inputs: [sample_logs]
+    endpoint: "https://splunk.example.com:8088"
+    token: "${SPLUNK_TOKEN}"
+    encoding:
+      codec: json


### PR DESCRIPTION
## Summary
- document how to forward logs from Datadog Agents to the Vector VIP
- show a mermaid architecture diagram with the load balancer and Observability Pipelines

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684adcf3f56c8332ae547e8ec6d0f4b0