### PR TITLE
Convert Vector configs to TOML

### DIFF
--- a/vector-test/README.md
+++ b/vector-test/README.md
@@ -1,0 +1,180 @@
+# Vector Centralized Deployment
+
+This repository provides an example of deploying [Vector](https://vector.dev/) in a centralized topology using Ansible and Docker.
+
+Vector will run in a container and accept logs, metrics, and traces from multiple sources:
+
+- **Datadog agents** via `vector` and `statsd` sources.
+- **Splunk** forwarders via `syslog` or `http`.
+- **OpenTelemetry (OTEL)** collectors via the `otlp` source.
+- **Filebeat** via `syslog`.
+
+Logs, metrics, and traces can be processed with VRL transforms and then routed to Datadog Observability Pipelines or sent directly to other sinks such as Datadog, Elasticsearch, and Splunk. The example configuration chains a `remap`, `filter`, `sample`, and `route` transform to demonstrate steering events to different destinations. The Observability Pipeline workers themselves are deployed separately; Vector simply forwards events to them via HTTP.
+
+Placeholders are used for tokens and endpoint URLs. Update them for your environment before deployment.
+
+## Directory Structure
+
+```
+vector-test/
+  ansible/
+    deploy.yml            # Playbook to deploy Vector
+    hosts.ini             # Inventory file with hosts
+    roles/
+      vector/
+        tasks/main.yml    # Tasks to run Vector container
+        templates/
+          vector.toml.j2  # Vector configuration template
+  docker-compose.yml
+  filebeat.yml
+  otel-collector-config.yaml
+  vector.toml
+```
+
+## Quick Start
+
+1. Edit `ansible/hosts.ini` and add the hosts where Vector should run.
+2. Edit `ansible/roles/vector/templates/vector.toml.j2` to customize sources, transforms, and sinks.
+3. Run the playbook:
+
+```bash
+ansible-playbook -i ansible/hosts.ini ansible/deploy.yml
+```
+
+Docker must be installed on the target host(s). The playbook will copy the Vector configuration and run the container.
+
+## Standalone Docker
+
+If you prefer to run Vector manually on a single host you can start the container directly with Docker:
+
+```bash
+docker run -d --name vector \
+  -v $(pwd)/vector.toml:/etc/vector/vector.toml:ro \
+  -e DD_API_KEY=YOUR_DD_API_KEY \
+  -e SPLUNK_TOKEN=YOUR_SPLUNK_TOKEN \
+  -p 4317:4317 -p 10514:10514 -p 9001:9001 -p 8125:8125 -p 1514:1514 \
+  timberio/vector:0.36.X-alpine
+```
+
+The command mounts the configuration from this repository and exposes the ports used by the sample config. Adjust tokens and endpoints as needed.
+
+
+
+## Local Docker Compose
+
+For local proof-of-concept testing you can run the stack with Docker Compose.
+The provided `docker-compose.yml` file starts Vector along with a Datadog Agent,
+Filebeat, an OpenTelemetry Collector and a small log generator. Observability
+Pipeline workers are assumed to run elsewhere.
+
+1. Install Docker and Docker Compose.
+2. Optionally set `DD_API_KEY` and `SPLUNK_TOKEN` in your environment.
+3. Launch the stack:
+
+```bash
+docker-compose up
+```
+
+Logs written by the `logger` container are picked up by Filebeat and the OTEL
+collector, then forwarded to Vector. The Datadog Agent also ships its own logs
+to the Vector service. Review `vector.toml` and the other config files in this
+directory to adjust sources or sinks.
+
+
+## Kubernetes Deployment with Datadog Agents
+
+This example assumes the Datadog Agent is already deployed as a Helm chart in multiple Kubernetes clusters. To forward container logs to the centralized Vector instance you can override the following values in the chart:
+
+```yaml
+# values.yaml snippet
+ datadog:
+   logs:
+     enabled: true
+     containerCollectAll: true
+   env:
+     - name: DD_LOGS_CONFIG_DD_URL
+       value: "http://VECTOR_VIP:9001"
+     - name: DD_LOGS_CONFIG_LOGS_DD_URL
+       value: "http://VECTOR_VIP:9001"
+```
+
+Replace `VECTOR_VIP` with the address of the central ingest VIP in front of Vector. Metrics and traces can also be pointed at this VIP or continue to use the default Datadog endpoints depending on your requirements. Observability Pipeline workers should also be reachable from Vector so that log routing works.
+
+### Running Vector in Kubernetes
+
+Vector can also run as a Deployment inside your cluster. First create a ConfigMap with the `vector.toml` configuration and then deploy a Deployment and Service:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config
+data:
+  vector.toml: |
+    # contents of vector.toml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: vector
+  template:
+    metadata:
+      labels:
+        app: vector
+    spec:
+      containers:
+      - name: vector
+        image: timberio/vector:0.36.X-alpine
+        args: ["--config", "/etc/vector/vector.toml"]
+        ports:
+        - containerPort: 9001
+        - containerPort: 8125
+        volumeMounts:
+        - name: config
+          mountPath: /etc/vector
+      volumes:
+      - name: config
+        configMap:
+          name: vector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector
+spec:
+  type: LoadBalancer
+  selector:
+    app: vector
+  ports:
+  - port: 9001
+    targetPort: 9001
+```
+
+Agents can then send logs to the service VIP while Vector forwards them on to Observability Pipelines or other sinks.
+
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Kubernetes Cluster"
+        A[Datadog Agent Daemonset] --> VIP[Central Ingest VIP]
+    end
+    VIP --> OP1[OP Worker 1]
+    VIP --> OP2[OP Worker 2]
+    VIP --> V[Vector Agents]
+    V --> OP1
+    V --> OP2
+    V --> ES[Elasticsearch]
+    V --> SP[Splunk]
+    V --> DD[Datadog]
+    OP1 --> DD
+    OP2 --> DD
+```
+
+All logs, metrics and traces are sent from the Datadog Agents to the central VIP. Vector can either forward events to the externally managed Observability Pipeline workers or send them straight to other sinks such as Datadog, Elasticsearch or Splunk depending on VRL routing rules.

--- a/vector-test/ansible/deploy.yml
+++ b/vector-test/ansible/deploy.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  become: yes
+  vars:
+    vector_config_path: /etc/vector/vector.toml
+    vector_version: "0.34.1"  # adjust as needed
+  roles:
+    - vector

--- a/vector-test/ansible/hosts.ini
+++ b/vector-test/ansible/hosts.ini
@@ -1,0 +1,2 @@
+[vector_servers]
+vector-host ansible_host=PLACEHOLDER_IP

--- a/vector-test/ansible/roles/vector/tasks/main.yml
+++ b/vector-test/ansible/roles/vector/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Ensure Vector config directory exists
+  file:
+    path: "/etc/vector"
+    state: directory
+    mode: '0755'
+
+- name: Deploy vector configuration
+  template:
+    src: vector.toml.j2
+    dest: "{{ vector_config_path }}"
+    mode: '0644'
+
+- name: Run Vector container
+  community.docker.docker_container:
+    name: vector
+    image: "timberio/vector:{{ vector_version }}-alpine"
+    state: started
+    restart_policy: unless-stopped
+    volumes:
+      - "{{ vector_config_path }}:/etc/vector/vector.toml:ro"
+    ports:
+      - "4317:4317"    # OTEL
+      - "10514:10514"  # Filebeat/Splunk syslog
+      - "9001:9001"    # Datadog logs
+      - "8125:8125/udp" # StatsD metrics
+    env:
+      DD_API_KEY: "{{ lookup('env','DD_API_KEY') | default('DD_API_KEY_PLACEHOLDER') }}"
+      SPLUNK_TOKEN: "{{ lookup('env','SPLUNK_TOKEN') | default('SPLUNK_TOKEN_PLACEHOLDER') }}"
+

--- a/vector-test/ansible/roles/vector/templates/vector.toml.j2
+++ b/vector-test/ansible/roles/vector/templates/vector.toml.j2
@@ -1,0 +1,80 @@
+# Vector configuration - centralized aggregator
+# Update endpoints and tokens as needed
+
+data_dir = "/var/lib/vector"
+
+[sources.otel]
+  type = "otlp"
+  address = "0.0.0.0:4317"
+
+[sources.filebeat_logs]
+  type = "syslog"
+  address = "0.0.0.0:10514"
+
+[sources.datadog_logs]
+  type = "vector"
+  address = "0.0.0.0:9001"
+
+[sources.datadog_metrics]
+  type = "statsd"
+  address = "0.0.0.0:8125"
+
+[sources.splunk_forwarder]
+  type = "syslog"
+  address = "0.0.0.0:1514"
+
+[transforms.add_tags]
+  type = "remap"
+  inputs = ["otel", "filebeat_logs", "datadog_logs", "datadog_metrics", "splunk_forwarder"]
+  source = '''
+  .tags.service = get(.service) ?? "unknown"
+  '''
+
+[transforms.filter_errors]
+  type = "filter"
+  inputs = ["add_tags"]
+  condition = '.log_level == "error"'
+
+[transforms.sample_logs]
+  type = "sample"
+  inputs = ["filter_errors"]
+  rate = 0.1
+
+[transforms.route_events]
+  type = "route"
+  inputs = ["sample_logs"]
+
+  [transforms.route_events.route]
+    op_worker_1 = '.service == "serviceA"'
+    op_worker_2 = '.service == "serviceB"'
+
+[sinks.op_worker_1]
+  type = "http"
+  inputs = ["route_events.op_worker_1"]
+  uri = "http://op-worker-1:8080/v1/input"
+
+[sinks.op_worker_2]
+  type = "http"
+  inputs = ["route_events.op_worker_2"]
+  uri = "http://op-worker-2:8081/v1/input"
+
+[sinks.to_datadog]
+  type = "datadog_logs"
+  inputs = ["route_events.other"]
+  default_api_key = "${DD_API_KEY}"
+  endpoint = "https://http-intake.logs.datadoghq.com/v1/input"
+
+[sinks.to_elasticsearch]
+  type = "elasticsearch"
+  inputs = ["route_events.other"]
+  endpoints = ["https://elasticsearch.example.com"]
+  index = "vector-%Y-%m-%d"
+
+[sinks.to_splunk]
+  type = "splunk_hec"
+  inputs = ["route_events.other"]
+  endpoint = "https://splunk.example.com:8088"
+  token = "${SPLUNK_TOKEN}"
+
+  [sinks.to_splunk.encoding]
+    codec = "json"

--- a/vector-test/docker-compose.yml
+++ b/vector-test/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+services:
+  vector:
+    image: "timberio/vector:0.34.1-alpine"
+    container_name: vector
+    volumes:
+      - ./vector.toml:/etc/vector/vector.toml:ro
+      - ./logs:/logs
+    ports:
+      - "4317:4317"
+      - "10514:10514"
+      - "1514:1514"
+      - "9001:9001"
+      - "8125:8125/udp"
+    environment:
+      DD_API_KEY: ${DD_API_KEY:-DD_API_KEY_PLACEHOLDER}
+      SPLUNK_TOKEN: ${SPLUNK_TOKEN:-SPLUNK_TOKEN_PLACEHOLDER}
+
+
+  datadog-agent:
+    image: datadog/agent:latest
+    environment:
+      DD_API_KEY: ${DD_API_KEY:-DD_API_KEY_PLACEHOLDER}
+      DD_LOGS_ENABLED: "true"
+      DD_LOGS_CONFIG_DD_URL: "http://vector:9001"
+      DD_LOGS_CONFIG_LOGS_DD_URL: "http://vector:9001"
+    depends_on:
+      - vector
+
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.9.0
+    command: ["--strict.perms=false", "-e"]
+    volumes:
+      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - ./logs:/logs:ro
+    depends_on:
+      - vector
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+      - ./logs:/logs:ro
+    depends_on:
+      - vector
+
+  logger:
+    image: busybox
+    volumes:
+      - ./logs:/logs
+    command: sh -c 'while true; do echo "$(date) sample log" >> /logs/sample.log; sleep 1; done'

--- a/vector-test/filebeat.yml
+++ b/vector-test/filebeat.yml
@@ -1,0 +1,8 @@
+filebeat.inputs:
+  - type: log
+    paths:
+      - /logs/*.log
+
+output.syslog:
+  protocol.tcp:
+    host: "vector:10514"

--- a/vector-test/otel-collector-config.yaml
+++ b/vector-test/otel-collector-config.yaml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+  filelog:
+    include:
+      - /logs/*.log
+
+exporters:
+  otlp:
+    endpoint: "vector:4317"
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/vector-test/vector.toml
+++ b/vector-test/vector.toml
@@ -1,0 +1,80 @@
+# Vector configuration - centralized aggregator
+# Update endpoints and tokens as needed
+
+data_dir = "/var/lib/vector"
+
+[sources.otel]
+  type = "otlp"
+  address = "0.0.0.0:4317"
+
+[sources.filebeat_logs]
+  type = "syslog"
+  address = "0.0.0.0:10514"
+
+[sources.datadog_logs]
+  type = "vector"
+  address = "0.0.0.0:9001"
+
+[sources.datadog_metrics]
+  type = "statsd"
+  address = "0.0.0.0:8125"
+
+[sources.splunk_forwarder]
+  type = "syslog"
+  address = "0.0.0.0:1514"
+
+[transforms.add_tags]
+  type = "remap"
+  inputs = ["otel", "filebeat_logs", "datadog_logs", "datadog_metrics", "splunk_forwarder"]
+  source = '''
+  .tags.service = get(.service) ?? "unknown"
+  '''
+
+[transforms.filter_errors]
+  type = "filter"
+  inputs = ["add_tags"]
+  condition = '.log_level == "error"'
+
+[transforms.sample_logs]
+  type = "sample"
+  inputs = ["filter_errors"]
+  rate = 0.1
+
+[transforms.route_events]
+  type = "route"
+  inputs = ["sample_logs"]
+
+  [transforms.route_events.route]
+    op_worker_1 = '.service == "serviceA"'
+    op_worker_2 = '.service == "serviceB"'
+
+[sinks.op_worker_1]
+  type = "http"
+  inputs = ["route_events.op_worker_1"]
+  uri = "http://op-worker-1:8080/v1/input"
+
+[sinks.op_worker_2]
+  type = "http"
+  inputs = ["route_events.op_worker_2"]
+  uri = "http://op-worker-2:8081/v1/input"
+
+[sinks.to_datadog]
+  type = "datadog_logs"
+  inputs = ["route_events.other"]
+  default_api_key = "${DD_API_KEY}"
+  endpoint = "https://http-intake.logs.datadoghq.com/v1/input"
+
+[sinks.to_elasticsearch]
+  type = "elasticsearch"
+  inputs = ["route_events.other"]
+  endpoints = ["https://elasticsearch.example.com"]
+  index = "vector-%Y-%m-%d"
+
+[sinks.to_splunk]
+  type = "splunk_hec"
+  inputs = ["route_events.other"]
+  endpoint = "https://splunk.example.com:8088"
+  token = "${SPLUNK_TOKEN}"
+
+  [sinks.to_splunk.encoding]
+    codec = "json"


### PR DESCRIPTION
## Summary
- switch Vector configuration files from YAML to TOML format
- update Ansible playbook and Docker compose to use `vector.toml`
- document new TOML-based configuration in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684adcf3f56c8332ae547e8ec6d0f4b0